### PR TITLE
fix: sync active preset state across frontend and backend

### DIFF
--- a/src-tauri/src/commands/preset_commands.rs
+++ b/src-tauri/src/commands/preset_commands.rs
@@ -68,3 +68,8 @@ pub fn sync_preset_from_config(name: String) -> Result<(), String> {
 pub fn set_active_preset(name: String) -> Result<(), String> {
     preset_service::set_active_preset(&name)
 }
+
+#[tauri::command]
+pub fn get_active_preset() -> Result<Option<String>, String> {
+    Ok(preset_service::get_active_preset())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
             commands::preset_commands::sync_preset_from_config,
             commands::preset_commands::apply_updates_to_preset,
             commands::preset_commands::set_active_preset,
+            commands::preset_commands::get_active_preset,
             commands::provider_commands::get_provider_status,
             commands::provider_commands::get_provider_config,
             commands::provider_commands::set_provider_api_key,

--- a/src/components/AgentList/AgentList.tsx
+++ b/src/components/AgentList/AgentList.tsx
@@ -14,6 +14,7 @@ import {
   updatePreset,
   savePreset,
   saveConfigSnapshot,
+  setActivePreset as persistActivePreset,
   type AgentConfig,
 } from '../../services/tauri';
 
@@ -127,6 +128,7 @@ export function AgentList({
 
     try {
       await savePreset(name);
+      await persistActivePreset(name);
       setActivePreset(name);
       await refreshPresetList(true);
       setShowSaveModal(false);

--- a/src/components/AgentList/AgentList.tsx
+++ b/src/components/AgentList/AgentList.tsx
@@ -128,12 +128,23 @@ export function AgentList({
 
     try {
       await savePreset(name);
-      await persistActivePreset(name);
       setActivePreset(name);
       await refreshPresetList(true);
       setShowSaveModal(false);
       setNewPresetName('');
       toast.success(t('presetSelector.saveSuccess', { name }));
+
+      try {
+        await persistActivePreset(name);
+      } catch (err) {
+        toast.warning(
+          err instanceof Error
+            ? err.message
+            : t('presetSelector.persistActivePresetFailed', {
+                defaultValue: '预设已保存，但当前活动预设同步失败',
+              })
+        );
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('presetSelector.saveFailed'));
     } finally {

--- a/src/components/Presets/PresetManager.tsx
+++ b/src/components/Presets/PresetManager.tsx
@@ -4,7 +4,7 @@ import { Bookmark, Plus, Trash2, Power, CheckCircle2, ChevronDown, ChevronRight,
 import { Button } from '../common/Button';
 import { Modal, ConfirmModal } from '../common/Modal';
 import { toast } from '../common/Toast';
-import { savePreset, loadPreset, deletePreset, renamePreset, getPresetInfo, getPresetMeta, saveConfigSnapshot } from '../../services/tauri';
+import { savePreset, loadPreset, deletePreset, renamePreset, getPresetInfo, getPresetMeta, saveConfigSnapshot, setActivePreset as persistActivePreset } from '../../services/tauri';
 import { usePresetStore } from '../../store/presetStore';
 import { usePreloadStore } from '../../store/preloadStore';
 
@@ -254,7 +254,8 @@ export function PresetManager() {
 
     try {
       setIsLoading(true);
-      await savePreset(newPresetName.trim());
+      const presetName = newPresetName.trim();
+      await savePreset(presetName);
       setShowSaveModal(false);
       setNewPresetName('');
       await loadPresetList();
@@ -337,6 +338,7 @@ export function PresetManager() {
     );
 
     if (activePreset === oldName) {
+      await persistActivePreset(trimmedName);
       setActivePreset(trimmedName);
     }
     if (selectedPreset === oldName) {

--- a/src/components/Presets/PresetManager.tsx
+++ b/src/components/Presets/PresetManager.tsx
@@ -338,8 +338,18 @@ export function PresetManager() {
     );
 
     if (activePreset === oldName) {
-      await persistActivePreset(trimmedName);
       setActivePreset(trimmedName);
+      try {
+        await persistActivePreset(trimmedName);
+      } catch (err) {
+        toast.warning(
+          err instanceof Error
+            ? err.message
+            : t('presetManager.persistActivePresetFailed', {
+                defaultValue: '预设已重命名，但当前活动预设同步失败',
+              })
+        );
+      }
     }
     if (selectedPreset === oldName) {
       setSelectedPreset(trimmedName);

--- a/src/components/Presets/PresetSelector.tsx
+++ b/src/components/Presets/PresetSelector.tsx
@@ -5,7 +5,7 @@ import { Select } from '../common/Select';
 import { Button } from '../common/Button';
 import { Modal } from '../common/Modal';
 import { toast } from '../common/Toast';
-import { loadPreset, savePreset, saveConfigSnapshot } from '../../services/tauri';
+import { loadPreset, savePreset, saveConfigSnapshot, setActivePreset as persistActivePreset } from '../../services/tauri';
 import { usePresetStore } from '../../store/presetStore';
 
 interface PresetSelectorProps {
@@ -76,6 +76,7 @@ export function PresetSelector({ onLoadPreset, compact }: PresetSelectorProps) {
 
     try {
       await savePreset(name);
+      await persistActivePreset(name);
       setActivePreset(name);
       await refreshPresetList(true);
       setShowSaveModal(false);

--- a/src/components/Presets/PresetSelector.tsx
+++ b/src/components/Presets/PresetSelector.tsx
@@ -76,12 +76,23 @@ export function PresetSelector({ onLoadPreset, compact }: PresetSelectorProps) {
 
     try {
       await savePreset(name);
-      await persistActivePreset(name);
       setActivePreset(name);
       await refreshPresetList(true);
       setShowSaveModal(false);
       setNewPresetName('');
       toast.success(t('presetSelector.saveSuccess', { name }));
+
+      try {
+        await persistActivePreset(name);
+      } catch (err) {
+        toast.warning(
+          err instanceof Error
+            ? err.message
+            : t('presetSelector.persistActivePresetFailed', {
+                defaultValue: '预设已保存，但当前活动预设同步失败',
+              })
+        );
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('presetSelector.saveFailed'));
     } finally {

--- a/src/services/tauri.ts
+++ b/src/services/tauri.ts
@@ -253,6 +253,10 @@ export async function setActivePreset(name: string): Promise<void> {
   return invoke<void>('set_active_preset', { name });
 }
 
+export async function getActivePreset(): Promise<string | null> {
+  return invoke<string | null>('get_active_preset');
+}
+
 export interface BackupInfo {
   filename: string;
   path: string;
@@ -385,6 +389,7 @@ const tauriService = {
   getPresetInfo,
   updatePreset,
   setActivePreset,
+  getActivePreset,
   exportOmoConfig,
   importOmoConfig,
   validateImport,

--- a/src/store/preloadStore.ts
+++ b/src/store/preloadStore.ts
@@ -23,6 +23,14 @@ interface GroupedModels {
   models: string[];
 }
 
+function isValidUserPreset(name: string | null | undefined, presets: string[]): name is string {
+  return Boolean(
+    name &&
+    !name.startsWith('__builtin__') &&
+    presets.includes(name)
+  );
+}
+
 interface PreloadState {
   // OMO 配置状态
   omoConfig: {
@@ -123,20 +131,9 @@ export const usePreloadStore = create<PreloadState>()(
 
         const currentPreset = usePresetStore.getState().activePreset;
         const persistedPreset = await loadActivePreset();
-        const hasPersistedPreset = Boolean(
-          persistedPreset &&
-          !persistedPreset.startsWith('__builtin__') &&
-          presets.includes(persistedPreset)
-        );
-        const hasLocalPreset = Boolean(
-          currentPreset &&
-          !currentPreset.startsWith('__builtin__') &&
-          presets.includes(currentPreset)
-        );
-
-        if (hasPersistedPreset && persistedPreset) {
+        if (isValidUserPreset(persistedPreset, presets)) {
           usePresetStore.getState().setActivePreset(persistedPreset);
-        } else if (hasLocalPreset && currentPreset) {
+        } else if (isValidUserPreset(currentPreset, presets)) {
           await persistActivePreset(currentPreset);
         } else {
           usePresetStore.getState().setActivePreset('default');

--- a/src/store/preloadStore.ts
+++ b/src/store/preloadStore.ts
@@ -7,6 +7,7 @@ import {
   fetchModelsDev,
   checkVersions,
   getOmoConfig,
+  getActivePreset as loadActivePreset,
   listPresets,
   savePreset,
   setActivePreset as persistActivePreset,
@@ -120,9 +121,24 @@ export const usePreloadStore = create<PreloadState>()(
           await savePreset('default');
         }
 
-        // 如果没有活跃预设，设置为 default
         const currentPreset = usePresetStore.getState().activePreset;
-        if (!currentPreset || currentPreset.startsWith('__builtin__')) {
+        const persistedPreset = await loadActivePreset();
+        const hasPersistedPreset = Boolean(
+          persistedPreset &&
+          !persistedPreset.startsWith('__builtin__') &&
+          presets.includes(persistedPreset)
+        );
+        const hasLocalPreset = Boolean(
+          currentPreset &&
+          !currentPreset.startsWith('__builtin__') &&
+          presets.includes(currentPreset)
+        );
+
+        if (hasPersistedPreset && persistedPreset) {
+          usePresetStore.getState().setActivePreset(persistedPreset);
+        } else if (hasLocalPreset && currentPreset) {
+          await persistActivePreset(currentPreset);
+        } else {
           usePresetStore.getState().setActivePreset('default');
           await persistActivePreset('default');
         }


### PR DESCRIPTION
## **User description**
## Summary
- add a Tauri command for reading the persisted active preset
- reconcile frontend and backend active preset state during preload with fallback to default
- persist the backend active preset when saving or renaming the current preset

## Testing
- `npm run build`
- `cargo test services::preset_service::tests`
- `cargo test` *(fails on existing unrelated test: `commands::provider_commands::tests::test_get_provider_status_graceful_when_auth_invalid`)*


___

## **CodeAnt-AI Description**
**Keep the active preset consistent after reloads, saves, and renames**

### What Changed
- On startup, the app now restores the last active preset from the backend instead of falling back to a different preset when one is already saved
- Saving a preset now marks it as the active preset right away in every save flow
- Renaming the currently active preset now keeps that preset active under its new name

### Impact
`✅ Preset selection survives app restarts`
`✅ Fewer cases where the wrong preset is shown after rename`
`✅ Clearer preset state after saving`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
